### PR TITLE
Retrieve events based on eventOrganizerID in the edit_event

### DIFF
--- a/Django/communicado/pages/views.py
+++ b/Django/communicado/pages/views.py
@@ -163,12 +163,24 @@ def organizer_actions(request):
     context = {"userData": userData, }
     return render (request,"pages/organizer_actions.html",context)
     
-
 def edit_event(request):
-    events = Events.objects.all()  
-    return render(request, 'pages/edit_event.html', {'events': events})
+    user_id = request.session.get('user_id')
+    user = users.objects.get(userID=user_id)
+    
+    if user.role.__eq__('EventOrganizer'):
+        try:
+            event_organizer = EventOrganizer.objects.get(user=user)
+            events = Events.objects.filter(eventOrganizerID=event_organizer)
+            return render(request, 'pages/edit_event.html', {'events': events})
+        except EventOrganizer.DoesNotExist:
+            error_message = "You are not authorized to access this page."
+            return render(request, 'error.html', {'error_message': error_message})
 
-from django.http import HttpResponseBadRequest
+
+    else:
+        error_message = f"An error occurred while retrieving the event. Role of user: {users.objects.get(userID=request.session.get('user_id')).role}. Type of user: {type(request.session.get('user_id'))}. Error: {str(e)}"
+        messages.error(request, error_message)
+        return redirect('edit_event')
 
     
 def change_event(request, event_ID):


### PR DESCRIPTION
The event organizer can only edit the events they have added.
- The edit_event.html file now displays the option to edit only the events the event organizer has added.
- No extra events have been added here.
- On clicking the "edit" button, the event organizer will be able to edit the event in the form submission and this will be updated in the database.
- Admin verification functionality will be done later.