### PR TITLE
Implemented - 'Push to production only after tests pass'

### DIFF
--- a/.github/workflows/pull_on_push.yml
+++ b/.github/workflows/pull_on_push.yml
@@ -5,13 +5,13 @@ on:
     branches:
       - main
   workflow_dispatch:
-
+    
 jobs:
   pull:
     runs-on: ubuntu-latest
+    needs: running_tests_py.notify-success
 
     steps:
-
       - name: SSH and Pull Changes
         uses: appleboy/ssh-action@master
         with:

--- a/.github/workflows/running_tests_py.yml
+++ b/.github/workflows/running_tests_py.yml
@@ -25,8 +25,16 @@ jobs:
         cd ./Django/communicado
         docker exec communicado_container_test python manage.py makemigrations
         docker exec communicado_container_test python manage.py migrate || true
-        
     - name: Run Tests
       run: |
         cd ./Django/communicado
         docker exec communicado_container_test python manage.py test
+
+  notify-success:
+    runs-on: ubuntu-latest
+    needs: test
+    if: ${{ always() }}
+
+    steps:
+    - name: Notify Success
+      run: echo "Tests ran successfully"


### PR DESCRIPTION
- Added 'notify-sucess' to running_tests_py.yml to facilitate push_on_pull only running when tests are successful
- Added 'needs' to 'push_on_pull' so that it only runs when tests have passed