### PR TITLE
Implemented admin approval for events

### DIFF
--- a/Django/communicado/pages/models.py
+++ b/Django/communicado/pages/models.py
@@ -58,14 +58,13 @@ class Events(models.Model):
     capacity = models.IntegerField(null=True, blank=True)
     category = models.CharField(max_length=50, null=True, blank=True)
     artist = models.CharField(max_length=100, null=True, blank=True)
-    isVerified = models.BooleanField(default=False)
-    #isVerified=models.IntegerField(default=0)
-    # IS_VERIFIED_CHOICES = (
-    #     (0, 'Not Checked'),
-    #     (1, 'Approved'),
-    #     (-1, 'Rejected'),
-    # )
-    # isVerified = models.IntegerField(choices=IS_VERIFIED_CHOICES, default=0)
+    #isVerified = models.BooleanField(default=False)
+    IS_VERIFIED_CHOICES = (
+        (0, 'Not Checked'),
+        (1, 'Approved'),
+        (-1, 'Rejected'),
+    )
+    isVerified = models.IntegerField(choices=IS_VERIFIED_CHOICES, default=0)
 
     adminID = models.ForeignKey(Admin, on_delete=models.CASCADE, null=True, blank=True,db_column= "adminID")
     eventOrganizerID = models.ForeignKey(EventOrganizer, on_delete=models.CASCADE, null=True, blank=True,db_column="eventOrganizerID")

--- a/Django/communicado/pages/templates/pages/admin_actions.html
+++ b/Django/communicado/pages/templates/pages/admin_actions.html
@@ -90,7 +90,6 @@
         <a href="login">Login</a>
         <a href="signup">Signup</a>
         <a href="#">View Cart</a>
-        <a href="admin">Admin Panel</a>
     </header>
 
     <div class="container">

--- a/Django/communicado/pages/templates/pages/eventaction.html
+++ b/Django/communicado/pages/templates/pages/eventaction.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pending Events</title>
+    <title>Edit Event - {{ event.name }}</title>
     <style>
         /* CSS for screen view */
         body {
@@ -109,7 +109,6 @@
             left: 0;
             width: 100%;
             z-index: 1000; 
-            margin-bottom: 50px;
         }
 
         header a {
@@ -146,66 +145,77 @@
 </head>
 <body>
     <header>
-        <p style="position: absolute; top: 0; left: 50%; transform: translateX(-50%); color: white;">Logged in as {{ request.session.user_id }}</p>
-        <a href="login">Login</a>
-        <a href="signup">Signup</a>
+        <a href="{% url 'login' %}">Login</a>
+        <a href="{% url 'signup' %}">Signup</a>
         <a href="#">View Cart</a>
-        <a href="admin">Admin Panel</a>
     </header>
-  
-    <div>
-        <h1>Pending Events</h1>
-        {% if pending %}
-            <ul>
-                {% for event in pending %}
-                <div class="event-container">
-                    <div class="event">
-                
-                        <div class="event-image">
-                            <img src="{% static event.imageURL %}" alt="Event Image">
-                        </div>
-                        <div class="event-details">
-                            <div class="event-name">{{ event.name }}</div>
-                            <div class="event-date">{{ event.eventDateTime }}</div>
-                            <div class="event-location">Location: {{ event.location }}</div>
-                          
-                            <div class="event-capacity">Capacity: {{ event.capacity }}</div>
-                
-                            <div class="event-category">Category: {{ event.category }}</div>
-                         
-                            <div class="event-artist">Artist: {{ event.artist }}</div>
-                           
-                            <div class="event-price">Price: {{ event.price }}</div>
-                            <div class="event-id">Event ID: {{ event.eventID }}</div>
-                            {% comment %} <button onclick="confirmApproval('{{ event.eventID }}')" class="btn-approve">Approve</button>
-                            <button onclick="confirmRejection('{{ event.eventID }}')" class="btn-reject">Reject</button> {% endcomment %}
-                            <a href="{% url 'eventaction' event_ID=event.eventID %}" class="btn btn-outline-secondary">Approve/Reject Event</a>
-                          
-                        </div>
-                    </div>
-                </div>
-                {% endfor %}
-            </ul>
-        {% else %}
-            <p>No pending events</p>
-        {% endif %}
+    <div class="container">
+        <h1>Update Event</h1>
+
+        <div class="event-container">
+            <h2>{{ event.name }} Details</h2>
+        <div class="event-details">
+            {% if event.imageURL %}
+            <div class="event-image">
+                <img src="{% static event.imageURL %}" alt="Event Image">
+            </div>{% endif %}
+            <div class="event-info">
+                <span class="label">Name:</span>
+                <span class="value">{{ event.name }}</span>
+            </div>
+            <div class="event-info">
+                <span class="label">Date and Time:</span>
+                <span class="value">{{ event.eventDateTime }}</span>
+            </div>
+            <div class="event-info">
+                <span class="label">Location:</span>
+                <span class="value">{{ event.location }}</span>
+            </div>
+            <div class="event-info">
+                <span class="label">Capacity:</span>
+                <span class="value">{{ event.capacity }}</span>
+            </div>
+            <div class="event-info">
+                <span class="label">Category:</span>
+                <span class="value">{{ event.category }}</span>
+            </div>
+            <div class="event-info">
+                <span class="label">Artist:</span>
+                <span class="value">{{ event.artist }}</span>
+            </div>
+            <div class="event-info">
+                <span class="label">Price:</span>
+                <span class="value">{{ event.price }}</span>
+            </div>
+            <div class="event-id">
+                <span class="label">Event ID:</span>
+                <span class="value">{{ event.eventID }}</span>
+            </div>
+           
+            <div>
+                <button class="btn" onclick="confirmApproval('{{ event.eventID }}')">Approve Event</button>
+                <button class="btn" onclick="confirmRejection('{{ event.eventID }}')">Reject Event</button>
+            </div>
+            
+           
+        
+        </div>
+        </div>
     </div>
-    {% comment %} <script>
+    <script>
         function confirmApproval(eventId) {
             var confirmation = confirm("Are you sure you want to approve this event?");
             if (confirmation) {
-                window.location.href = "{% url 'approve_event' %}?event_id=" + eventId;
+               window.location.href = "{% url 'approve_event' event_ID=event.eventID %}";
             }
         }
 
         function confirmRejection(eventId) {
             var confirmation = confirm("Are you sure you want to reject this event?");
             if (confirmation) {
-                window.location.href = "{% url 'reject_event' %}?event_id=" + eventId;
+                window.location.href = "{% url 'reject_event' event_ID=event.eventID%}";
             }
         }
-    </script> {% endcomment %}
-    
-    
+    </script>
 </body>
 </html>

--- a/Django/communicado/pages/templates/pages/pending.html
+++ b/Django/communicado/pages/templates/pages/pending.html
@@ -177,8 +177,7 @@
                            
                             <div class="event-price">Price: {{ event.price }}</div>
                             <div class="event-id">Event ID: {{ event.eventID }}</div>
-                            {% comment %} <button onclick="confirmApproval('{{ event.eventID }}')" class="btn-approve">Approve</button>
-                            <button onclick="confirmRejection('{{ event.eventID }}')" class="btn-reject">Reject</button> {% endcomment %}
+                        
                             <a href="{% url 'eventaction' event_ID=event.eventID %}" class="btn btn-outline-secondary">Approve/Reject Event</a>
                           
                         </div>
@@ -190,21 +189,6 @@
             <p>No pending events</p>
         {% endif %}
     </div>
-    {% comment %} <script>
-        function confirmApproval(eventId) {
-            var confirmation = confirm("Are you sure you want to approve this event?");
-            if (confirmation) {
-                window.location.href = "{% url 'approve_event' %}?event_id=" + eventId;
-            }
-        }
-
-        function confirmRejection(eventId) {
-            var confirmation = confirm("Are you sure you want to reject this event?");
-            if (confirmation) {
-                window.location.href = "{% url 'reject_event' %}?event_id=" + eventId;
-            }
-        }
-    </script> {% endcomment %}
     
     
 </body>

--- a/Django/communicado/pages/templates/pages/rejected.html
+++ b/Django/communicado/pages/templates/pages/rejected.html
@@ -1,9 +1,196 @@
+{% load static %}
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <title>Page Title</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Rejected Events</title>
+    <style>
+        /* CSS for screen view */
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #0c0808;
+            margin: 0;
+            padding: 0;
+        }
+
+        h1, h2 {
+            color: #fff;
+            text-align: center;
+            margin-bottom: 20px;
+            font-size: 24px;
+        }
+
+        .container {
+            margin: 20px auto;
+            padding: 20px;
+            background-color: #0e0101;
+            border-radius: 5px;
+            box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+            width: 80%;
+        }
+
+        .event-container {
+            margin-bottom: 20px;
+            padding: 10px;
+            border: 1px solid #ddd; /* Add border to separate events */
+            border-radius: 5px; /* Add rounded corners */
+        }
+
+        .event {
+            display: flex; /* Use flexbox */
+            align-items: center; /* Center align items vertically */
+            margin-bottom: 20px;
+        }
+
+        .event-details {
+            flex: 1; /* Take up remaining space */
+            padding: 20px;
+            color: #fff;
+        }
+
+        .event-details > * {
+            margin-bottom: 10px; /* Add spacing between elements */
+            color: #fff;
+        }
+
+        .event-image {
+            margin-left: 20px; /* Add margin to separate image from text */
+            width: 800px; /* Set a fixed width for the image */
+            margin-bottom: 10px;
+            margin-top: 20px;
+            height: 500px;
+        }
+
+        .event-image img {
+            width: 100%; /* Make the image fill its container */
+            border-radius: 5px; /* Add rounded corners */
+        }
+
+        .btn {
+            display: inline-block;
+            padding: 10px 20px;
+            font-size: 18px;
+            background-color: transparent; 
+            color: #fff; 
+            text-decoration: none;
+            border: 2px solid #fff; 
+            border-radius: 5px;
+            margin-top: 20px;
+            transition: background-color 0.3s, border-color 0.3s, color 0.3s; 
+            text-align: center;
+        }
+
+        .btn:hover {
+            background-color: #fff; 
+            border-color: #fff; 
+            color: #000; 
+        }
+
+        h1 {
+            text-align: center; /* Center-align the title */
+            color: #fff;
+        }
+
+        .event-name {
+            text-align: left; /* Center-align the event name */
+            font-weight: bold;
+            font-size: medium;
+            color: #fff;
+        }
+
+        header {
+            background-color: rgba(0, 0, 0, 0.7); 
+            color: #fff;
+            padding: 10px;
+            text-align: right;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            z-index: 1000; 
+            margin-bottom: 50px;
+        }
+
+        header a {
+            color: #fff;
+            margin: 0 10px;
+            text-decoration: none;
+        }
+
+        header a:hover {
+            text-decoration: underline;
+        }
+
+        /* CSS for print view */
+        @media print {
+            body {
+                background-color: #fff; /* Change background color for print */
+            }
+
+            .container {
+                width: 100%; /* Ensure full width for print */
+                margin: 0; /* Remove margin for print */
+                padding: 0; /* Remove padding for print */
+            }
+
+            .btn {
+                display: none; /* Hide buttons for print */
+            }
+
+            header {
+                display: none; /* Hide header for print */
+            }
+        }
+    </style>
 </head>
 <body>
-    <h1>Rejected</h1>
+    <header>
+        <p style="position: absolute; top: 0; left: 50%; transform: translateX(-50%); color: white;">Logged in as {{ request.session.user_id }}</p>
+        <a href="login">Login</a>
+        <a href="signup">Signup</a>
+        <a href="#">View Cart</a>
+
+    </header>
+  
+    <div>
+        <h1>Rejected Events</h1>
+        {% if pending %}
+            <ul>
+                {% for event in pending %}
+                <div class="event-container">
+                    <div class="event">
+                
+                        <div class="event-image">
+                            <img src="{% static event.imageURL %}" alt="Event Image">
+                        </div>
+                        <div class="event-details">
+                            <div class="event-name">{{ event.name }}</div>
+                            <div class="event-date">{{ event.eventDateTime }}</div>
+                            <div class="event-location">Location: {{ event.location }}</div>
+                          
+                            <div class="event-capacity">Capacity: {{ event.capacity }}</div>
+                
+                            <div class="event-category">Category: {{ event.category }}</div>
+                         
+                            <div class="event-artist">Artist: {{ event.artist }}</div>
+                           
+                            <div class="event-price">Price: {{ event.price }}</div>
+                            <div class="event-id">Event ID: {{ event.eventID }}</div>
+                        
+                            <a href="{% url 'eventaction' event_ID=event.eventID %}" class="btn btn-outline-secondary">Approve Event</a>
+                          
+                        </div>
+                    </div>
+                </div>
+                {% endfor %}
+            </ul>
+        {% else %}
+            <p>No rejected events</p>
+        {% endif %}
+    </div>
+
+    
+    
 </body>
 </html>

--- a/Django/communicado/pages/urls.py
+++ b/Django/communicado/pages/urls.py
@@ -19,6 +19,9 @@ urlpatterns = [
     path('admin_actions', views.admin_actions, name='admin_actions'),
     path('pending', views.pending, name='pending'),
     path('rejected', views.rejected, name='rejected'),
+    path('eventaction/<int:event_ID>', views.eventaction, name='eventaction'),
+    path('approve_event/<int:event_ID>', views.approve_event, name='approve_event'),
+    path('reject_event/<int:event_ID>', views.reject_event, name='reject_event'),
 
  
 ]

--- a/Django/communicado/pages/views.py
+++ b/Django/communicado/pages/views.py
@@ -302,21 +302,12 @@ def admin_actions(request):
 
 def pending(request):
     pending = Events.objects.filter(isVerified=0)
-    # if request.method == 'POST':
-    #     event_id = request.POST.get('event_id')
-    #     action = request.POST.get('action')
-    #     if action == 'approve':
-    #         event = Events.objects.get(id=event_id)
-    #         event.isVerified = 1
-    #         event.save()
-
     return render(request, 'pages/pending.html', {'pending': pending})
 
     
 def rejected(request):
-    userData = users.objects.all()
-    context = {"rejected": userData, }
-    return render (request,"pages/rejected.html",context)
+    rejected = Events.objects.filter(isVerified=-1)
+    return render(request, 'pages/rejected.html', {'rejected': rejected})
 def eventaction(request,event_ID):
     # userData = users.objects.all()
     # context = {"eventaction": userData, }

--- a/Django/communicado/pages/views.py
+++ b/Django/communicado/pages/views.py
@@ -62,7 +62,7 @@ def signup(request):
         if role.__eq__('EventOrganizer'):
             event_organizer = EventOrganizer(user=user, phoneNumber=phoneNumber)
             event_organizer.save()
-    
+ 
         success_message = "User Account Created for: " + user.name
         return render(request, 'pages/login.html', {'success_message': success_message})
         
@@ -301,12 +301,39 @@ def admin_actions(request):
     return render (request,"pages/admin_actions.html",context)
 
 def pending(request):
-    userData = users.objects.all()
-    context = {"userData": userData, }
-    return render (request,"pages/pending.html",context)
+    pending = Events.objects.filter(isVerified=0)
+    # if request.method == 'POST':
+    #     event_id = request.POST.get('event_id')
+    #     action = request.POST.get('action')
+    #     if action == 'approve':
+    #         event = Events.objects.get(id=event_id)
+    #         event.isVerified = 1
+    #         event.save()
+
+    return render(request, 'pages/pending.html', {'pending': pending})
+
     
 def rejected(request):
     userData = users.objects.all()
     context = {"rejected": userData, }
     return render (request,"pages/rejected.html",context)
+def eventaction(request,event_ID):
+    # userData = users.objects.all()
+    # context = {"eventaction": userData, }
+    # return render (request,"pages/eventaction.html",context)
+
+    event = get_object_or_404(Events,eventID=event_ID)
+    return render(request, 'pages/eventaction.html', {'event': event})
+
+
+def approve_event(request, event_ID):
+    event = get_object_or_404(Events,eventID=event_ID)
+    event.isVerified = 1 
+    event.save()
+    return redirect('pending')
     
+def reject_event(request, event_ID):
+    event = get_object_or_404(Events,eventID=event_ID)
+    event.isVerified = -1  
+    event.save()
+    return redirect('pending')

--- a/Django/communicado/pages/views.py
+++ b/Django/communicado/pages/views.py
@@ -118,7 +118,7 @@ def useracc(request):
 
 
 def event(request):
-    data = Events.objects.all()
+    data = Events.objects.filter(isVerified=1)
     unique_categories = Events.objects.values_list('category', flat=True).distinct()
     category = request.GET.get('category')
     search_query = request.GET.get('search')
@@ -130,7 +130,7 @@ def event(request):
             Q(category__icontains=search_query))
             if(data.count() == 0):
                 error_message = "No Matches for "+ search_query+" :( Currently available Events: "
-                data = Events.objects.all()
+                data = Events.objects.filter(isVerified=1)
                 context = {"events": data ,
                 'unique_categories': unique_categories,
                 'error_message': error_message
@@ -138,24 +138,24 @@ def event(request):
                 return render (request , "pages/events.html",context)
                 
         else:
-            data=Events.objects.filter(category=category)
+            data=Events.objects.filter(category=category, isVerified=1)
             context = {"events": data ,
                 'unique_categories': unique_categories}
     else:
         if search_query and search_query != " ":
             data = Events.objects.filter(
             Q(artist__icontains=search_query) |
-            Q(name__icontains=search_query) )
+            Q(name__icontains=search_query))
             if(data.count() == 0):
                 error_message = "No Matches for "+ search_query+" :( Currently available Events: "
-                data = Events.objects.all()
+                data = Events.objects.filter(isVerified=1)
                 context = {"events": data ,
                 'unique_categories': unique_categories,
                 'error_message': error_message
                 }
                 return render (request , "pages/events.html",context)
         else:
-            data=Events.objects.all()
+            data=Events.objects.filter(isVerified=1)
            
     context = {"events": data ,
                 'unique_categories': unique_categories}


### PR DESCRIPTION
As required, the admin will now be able to approve (or reject) events added by the event organizer prior to being added in the system.
- Modified the "isVerified" field in the Events database and model to take in integer values of -1 (rejected), 0 (pending), 1 (approved) instead of taking a boolean true/false value.
- For each pending event there is a "accept/reject" button which when clicked is directed to a page containing the event details where the admin will be able to accept or reject the event, and there are two buttons for the same.
- A dialogue box appears after the admin clicks on the accept or reject event for confirmation.
- JavaScript functionality implemented for the buttons
- Furthermore, the view current event page only shows all approved events (isVerified=1).
- The view rejected events page is still being implemented.