### PR TITLE
AdminID of the admin who approved the event added in database

### DIFF
--- a/Django/communicado/pages/views.py
+++ b/Django/communicado/pages/views.py
@@ -321,12 +321,26 @@ def eventaction(request,event_ID):
 
 def approve_event(request, event_ID):
     event = get_object_or_404(Events,eventID=event_ID)
+    user_id = request.session.get('userID')
+    user = users.objects.get(userID=user_id)
+    if user.role.__eq__('Admin'):
+        admin = Admin.objects.get(user=user)
+    else:
+        raise Exception("User is not an Event Organizer")
+    event.adminID=admin
     event.isVerified = 1 
     event.save()
     return redirect('pending')
     
 def reject_event(request, event_ID):
     event = get_object_or_404(Events,eventID=event_ID)
+    user_id = request.session.get('userID')
+    user = users.objects.get(userID=user_id)
+    if user.role.__eq__('Admin'):
+        admin = Admin.objects.get(user=user)
+    else:
+        raise Exception("User is not an Event Organizer")
+    event.adminID=admin
     event.isVerified = -1  
     event.save()
     return redirect('pending')


### PR DESCRIPTION
- Minor fix: previously adminID was null for each event in the database.
- Now the adminID in the events table in the database will be set to the user ID of the admin who approves or rejects an event.