### PR TITLE
Implement Admin Verification for Updated Events

### DIFF
--- a/Django/communicado/pages/views.py
+++ b/Django/communicado/pages/views.py
@@ -209,12 +209,13 @@ def change_event(request, event_ID):
         event.category = request.POST.get('category')
         event.artist = request.POST.get('artist')
         event.price = request.POST.get('price')
+        event.isVerified=False
         # event.imageURL = request.POST.get('image')
         event.save()
 
-        success_message = "Event updated successfully."
+        success_message = "Updated event details sent to admin for approval."
         messages.success(request, success_message)
-        return redirect('home')  
+        return redirect('organizer_actions')  
     else:
         # Render the form template with the event data for editing
         return render(request, 'pages/change_event.html', {'event': event})


### PR DESCRIPTION
Previously, when an event organizer updates an event they added, it is directly updated in the system.
Updated functionality: Now, the admin must verify the updated event prior to being added in the system.
- When the event is updated, the isVerified field is set to 0 so the event is removed from the system until the admin approves it.
- If the admin approves the event, it is added back in the system with the updated details.
- Minor bug fix: once the event organizer updates an event, the system redirects the organizer to the organizer actions page.